### PR TITLE
Implement Near Search Operator

### DIFF
--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/NearSearchOperatorDsl.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/NearSearchOperatorDsl.kt
@@ -50,7 +50,7 @@ class NearSearchOperatorDsl {
      * @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/path-construction/#std-label-ref-path">Path Construction</a>
      */
     @JvmName("pathDate")
-    fun path(vararg path: KProperty<Temporal>) {
+    fun path(vararg path: KProperty<Temporal?>) {
         document["path"] = path.map { it.toDotPath() }.firstOrAll()
     }
 
@@ -62,7 +62,7 @@ class NearSearchOperatorDsl {
      * @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/path-construction/#std-label-ref-path">Path Construction</a>
      */
     @JvmName("pathPoint")
-    fun path(vararg path: KProperty<GeoJsonPoint>) {
+    fun path(vararg path: KProperty<GeoJsonPoint?>) {
         document["path"] = path.map { it.toDotPath() }.firstOrAll()
     }
 

--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/NearSearchOperatorDsl.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/NearSearchOperatorDsl.kt
@@ -100,9 +100,12 @@ class NearSearchOperatorDsl {
 
     /**
      * Value to use to calculate scores of Atlas Search result documents. Score is calculated using the following formula:
+     *
+     * ```
      *               pivot
      * score = ------------------
      *          pivot + distance
+     * ```
      *
      * where distance is the difference between origin and the indexed field value.
      *
@@ -113,6 +116,8 @@ class NearSearchOperatorDsl {
      * - Number, pivot can be specified as an integer or floating point number.
      * - Date, pivot must be specified in milliseconds and can be specified as a 32 or 64 bit integer.
      * - GeoJSON point, pivot is measured in meters and must be specified as an integer or floating point number.
+     *
+     * @param pivot The value to use to calculate scores of Atlas Search result documents.
      */
     fun pivot(pivot: Number) {
         document["pivot"] = pivot

--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/NearSearchOperatorDsl.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/NearSearchOperatorDsl.kt
@@ -1,0 +1,137 @@
+package com.github.inflab.spring.data.mongodb.core.aggregation.search
+
+import com.github.inflab.spring.data.mongodb.core.annotation.AggregationMarker
+import com.github.inflab.spring.data.mongodb.core.extension.firstOrAll
+import com.github.inflab.spring.data.mongodb.core.extension.toDotPath
+import org.bson.Document
+import org.springframework.data.mongodb.core.geo.GeoJson
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint
+import java.time.temporal.Temporal
+import kotlin.reflect.KProperty
+
+/**
+ * A Kotlin DSL to configure near search operator using idiomatic Kotlin code.
+ *
+ * @author username1103
+ * @since 1.0
+ * @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/near">near</a>
+ */
+@AggregationMarker
+class NearSearchOperatorDsl {
+    private val document = Document()
+
+    /**
+     * Indexed field or fields to search.
+     * See Path Construction.
+     *
+     * @param path The indexed field or fields to search.
+     * @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/path-construction/#std-label-ref-path">Path Construction</a>
+     */
+    fun path(vararg path: String) {
+        document["path"] = path.toList().firstOrAll()
+    }
+
+    /**
+     * Indexed number type field or fields to search.
+     * See Path Construction.
+     *
+     * @param path The indexed field or fields to search.
+     * @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/path-construction/#std-label-ref-path">Path Construction</a>
+     */
+    @JvmName("pathNumber")
+    fun path(vararg path: KProperty<Number?>) {
+        document["path"] = path.map { it.toDotPath() }.firstOrAll()
+    }
+
+    /**
+     * Indexed date type field or fields to search.
+     * See Path Construction.
+     *
+     * @param path The indexed field or fields to search.
+     * @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/path-construction/#std-label-ref-path">Path Construction</a>
+     */
+    @JvmName("pathDate")
+    fun path(vararg path: KProperty<Temporal>) {
+        document["path"] = path.map { it.toDotPath() }.firstOrAll()
+    }
+
+    /**
+     * Indexed geo type field or fields to search.
+     * See Path Construction for more information.
+     *
+     * @param path The indexed field or fields to search.
+     * @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/path-construction/#std-label-ref-path">Path Construction</a>
+     */
+    @JvmName("pathPoint")
+    fun path(vararg path: KProperty<GeoJsonPoint>) {
+        document["path"] = path.map { it.toDotPath() }.firstOrAll()
+    }
+
+    /**
+     * Origin to query for Number field.
+     * This is the origin from which the proximity of the results is measured.
+     *
+     * For number fields, the value must be of BSON int32, int64, or double data types.
+     */
+    fun origin(origin: Number) {
+        document["origin"] = origin
+    }
+
+    /**
+     * Origin to query for Date field.
+     * This is the origin from which the proximity of the results is measured.
+     *
+     * For date fields, the value must be an ISODate formatted date.
+     * @see <a href="https://www.mongodb.com/docs/upcoming/reference/glossary/#std-term-ISODate">ISODate</a>
+     */
+    fun origin(origin: Temporal) {
+        document["origin"] = origin
+    }
+
+    /**
+     * Origin to query for Geo field.
+     * This is the origin from which the proximity of the results is measured.
+     *
+     * For geo fields. the value must be a GeoJSON point.
+     * @see <a href="https://www.mongodb.com/docs/upcoming/reference/geojson/#std-label-geojson-point">GeoJson Point</a>
+     */
+    fun origin(origin: GeoJsonPoint) {
+        document["origin"] = Document("type", "Point").append("coordinates", origin.coordinates)
+    }
+
+    /**
+     * Value to use to calculate scores of Atlas Search result documents. Score is calculated using the following formula:
+     *               pivot
+     * score = ------------------
+     *          pivot + distance
+     *
+     * where distance is the difference between origin and the indexed field value.
+     *
+     * Results have a score equal to 1/2 (or 0.5) when their indexed field value is pivot units away from origin.
+     * The value of pivot must be greater than (i.e. >) 0.
+     *
+     * If origin is a:
+     * - Number, pivot can be specified as an integer or floating point number.
+     * - Date, pivot must be specified in milliseconds and can be specified as a 32 or 64 bit integer.
+     * - GeoJSON point, pivot is measured in meters and must be specified as an integer or floating point number.
+     */
+    fun pivot(pivot: Number) {
+        document["pivot"] = pivot
+    }
+
+    /**
+     * The score assigned to matching search term results. Use one of the following options to modify the score:
+     *
+     * - boost: multiply the result score by the given number.
+     * - constant: replace the result score with the given number.
+     * - function: replace the result score using the given expression.
+     *
+     *  @param scoreConfiguration The configuration block for [ScoreSearchOptionDsl]
+     *  @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/score/modify-score">Modify the Score</a>
+     */
+    fun score(scoreConfiguration: ScoreSearchOptionDsl.() -> Unit) {
+        document["score"] = ScoreSearchOptionDsl().apply(scoreConfiguration).get()
+    }
+
+    internal fun build() = Document("near", document)
+}

--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/NearSearchOperatorDsl.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/NearSearchOperatorDsl.kt
@@ -4,7 +4,6 @@ import com.github.inflab.spring.data.mongodb.core.annotation.AggregationMarker
 import com.github.inflab.spring.data.mongodb.core.extension.firstOrAll
 import com.github.inflab.spring.data.mongodb.core.extension.toDotPath
 import org.bson.Document
-import org.springframework.data.mongodb.core.geo.GeoJson
 import org.springframework.data.mongodb.core.geo.GeoJsonPoint
 import java.time.temporal.Temporal
 import kotlin.reflect.KProperty

--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/SearchOperator.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/SearchOperator.kt
@@ -125,4 +125,14 @@ interface SearchOperator {
      * @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/queryString">queryString</a>
      */
     fun queryString(configuration: QueryStringSearchOperatorDsl.() -> Unit)
+
+    /**
+     * Supports querying and scoring numeric, date, and GeoJSON point values.
+     * You can use the near operator to find results that are near a number or a date.
+     * The near operator scores the Atlas Search results by proximity to the number or date.
+     *
+     * @param configuration The Configuration block for the [NearSearchOperatorDsl].
+     * @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/near">near</a>
+     */
+    fun near(configuration: NearSearchOperatorDsl.() -> Unit)
 }

--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/SearchOperatorDsl.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/SearchOperatorDsl.kt
@@ -61,4 +61,8 @@ class SearchOperatorDsl : SearchOperator {
     override fun queryString(configuration: QueryStringSearchOperatorDsl.() -> Unit) {
         operators.add(QueryStringSearchOperatorDsl().apply(configuration).build())
     }
+
+    override fun near(configuration: NearSearchOperatorDsl.() -> Unit) {
+        operators.add(NearSearchOperatorDsl().apply(configuration).build())
+    }
 }

--- a/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/NearSearchOperatorDslTest.kt
+++ b/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/NearSearchOperatorDslTest.kt
@@ -1,0 +1,237 @@
+package com.github.inflab.spring.data.mongodb.core.aggregation.search
+
+import com.github.inflab.spring.data.mongodb.core.mapping.rangeTo
+import com.github.inflab.spring.data.mongodb.core.util.shouldBeJson
+import io.kotest.core.spec.style.FreeSpec
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+internal class NearSearchOperatorDslTest : FreeSpec({
+    fun near(block: NearSearchOperatorDsl.() -> Unit): NearSearchOperatorDsl =
+        NearSearchOperatorDsl().apply(block)
+
+    "path" - {
+        "should build a path by strings" {
+            // given
+            val operator = near {
+                path("path1", "path2")
+            }
+
+            // when
+            val result = operator.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "near": {
+                    "path": [
+                      "path1",
+                      "path2"
+                    ]
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        "should build a path by multiple properties" {
+            // given
+            data class TestCollection(val path1: Number, val path2: Number)
+
+            val operator = near {
+                path(TestCollection::path1, TestCollection::path2)
+            }
+
+            // when
+            val result = operator.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "near": {
+                    "path": [
+                      "path1",
+                      "path2"
+                    ]
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        "should build a path by nested property" {
+            // given
+            data class Child(val path: Number)
+            data class Parent(val child: Child)
+
+            val operator = near {
+                path(Parent::child..Child::path)
+            }
+
+            // when
+            val result = operator.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "near": {
+                    "path": "child.path"
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+    }
+
+    "origin" - {
+        "should build a origin by number" {
+            // given
+            val operator = near {
+                origin(123)
+            }
+
+            // when
+            val result = operator.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "near": {
+                    "origin": 123
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        "should build a origin by LocalDateTime" {
+            // given
+            val operator = near {
+                origin(LocalDateTime.of(2023, 9, 18, 4, 10, 50, 1))
+            }
+
+            // when
+            val result = operator.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "near": {
+                    "origin": {
+                      "${'$'}date": "2023-09-18T04:10:50Z"
+                    }
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        "should build a origin by LocalDate" {
+            // given
+            val operator = near {
+                origin(LocalDate.of(2023, 9, 18))
+            }
+
+            // when
+            val result = operator.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "near": {
+                    "origin": {
+                      "${'$'}date": "2023-09-18T00:00:00Z"
+                    }
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        "should build a origin by GeoJson Point" {
+            // given
+            val operator = near {
+                origin(GeoJsonPoint(1.0, 2.0))
+            }
+
+            // when
+            val result = operator.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "near": {
+                    "origin": {
+                      "type": "Point",
+                      "coordinates": [
+                        1.0,
+                        2.0
+                      ]
+                    }
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+    }
+
+    "pivot" - {
+        "should build a pivot by Number" {
+            // given
+            val operator = near {
+                pivot(123)
+            }
+
+            // when
+            val result = operator.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "near": {
+                    "pivot": 123
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+    }
+
+    "score" - {
+        "should build a score" {
+            // given
+            val operator = near {
+                score {
+                    boost(5.0)
+                }
+            }
+
+            // when
+            val result = operator.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "near": {
+                    "score": {
+                      "boost": {
+                        "value": 5.0
+                      }
+                    }
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+    }
+})

--- a/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/annotation/Database.kt
+++ b/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/annotation/Database.kt
@@ -1,0 +1,4 @@
+package com.github.inflab.example.spring.data.mongodb.annotation
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class Database(val value: String)

--- a/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/entity/airbnb/ListingsAndReviews.kt
+++ b/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/entity/airbnb/ListingsAndReviews.kt
@@ -2,11 +2,14 @@ package com.github.inflab.example.spring.data.mongodb.entity.airbnb
 
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
+import org.springframework.data.mongodb.core.mapping.Field
 
 @Document("listingsAndReviews")
 data class ListingsAndReviews(
     @Id
     val id: String,
     val name: String,
+    @Field("property_type")
+    val propertyType: String,
     val address: ListingsAndReviewsAddress,
 )

--- a/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/atlas/NearSearchRepository.kt
+++ b/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/atlas/NearSearchRepository.kt
@@ -1,0 +1,80 @@
+package com.github.inflab.example.spring.data.mongodb.repository.atlas
+
+import com.github.inflab.example.spring.data.mongodb.entity.airbnb.ListingsAndReviewsAddress
+import com.github.inflab.spring.data.mongodb.core.aggregation.aggregation
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.aggregation.AggregationResults
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
+@Repository
+class NearSearchRepository(
+    private val mongoTemplate: MongoTemplate,
+) {
+
+    data class RuntimeDto(
+        val title: String,
+        val runtime: Int,
+        val score: Double,
+    )
+
+    data class ReleasedDto(
+        val title: String,
+        val released: LocalDateTime,
+        val score: Double,
+    )
+
+    data class GeoDto(
+        val title: String,
+        val address: ListingsAndReviewsAddress,
+        val score: Double,
+    )
+
+    fun findByRuntime(): AggregationResults<RuntimeDto> {
+        val aggregation = aggregation {
+            search {
+                index = "runtimes"
+                near {
+                    path("runtime")
+                    origin(279)
+                    pivot(2)
+                }
+            }
+
+            // TODO: add $limit stage
+
+            project {
+                excludeId()
+                +"title"
+                +"runtime"
+                searchScore()
+            }
+        }
+
+        return mongoTemplate.aggregate(aggregation, "movies", RuntimeDto::class.java)
+    }
+
+    fun findByDate(): AggregationResults<ReleasedDto> {
+        val aggregation = aggregation {
+            search {
+                index = "releaseddate"
+                near {
+                    path("released")
+                    origin(LocalDateTime.of(1915, 9, 13, 0, 0, 0))
+                    pivot(7776000000)
+                }
+            }
+
+            // TODO: add $limit stage
+
+            project {
+                excludeId()
+                +"title"
+                +"released"
+                searchScore()
+            }
+        }
+
+        return mongoTemplate.aggregate(aggregation, "movies", ReleasedDto::class.java)
+    }
+}

--- a/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/atlas/NearSearchRepository.kt
+++ b/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/atlas/NearSearchRepository.kt
@@ -3,9 +3,11 @@ package com.github.inflab.example.spring.data.mongodb.repository.atlas
 import com.github.inflab.example.spring.data.mongodb.annotation.Database
 import com.github.inflab.example.spring.data.mongodb.entity.airbnb.ListingsAndReviews
 import com.github.inflab.example.spring.data.mongodb.entity.airbnb.ListingsAndReviewsAddress
+import com.github.inflab.example.spring.data.mongodb.entity.mflix.Movies
 import com.github.inflab.spring.data.mongodb.core.aggregation.aggregation
 import com.github.inflab.spring.data.mongodb.core.mapping.rangeTo
 import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.aggregate
 import org.springframework.data.mongodb.core.aggregation.AggregationResults
 import org.springframework.data.mongodb.core.geo.GeoJsonPoint
 import org.springframework.data.mongodb.core.mapping.Field
@@ -51,7 +53,7 @@ class NearSearchRepository(
             search {
                 index = "runtimes"
                 near {
-                    path("runtime")
+                    path(Movies::runtime)
                     origin(279)
                     pivot(2)
                 }
@@ -61,13 +63,13 @@ class NearSearchRepository(
 
             project {
                 excludeId()
-                +"title"
-                +"runtime"
+                +Movies::title
+                +Movies::runtime
                 searchScore()
             }
         }
 
-        return mflixMongoTemplate.aggregate(aggregation, "movies", RuntimeDto::class.java)
+        return mflixMongoTemplate.aggregate<Movies, RuntimeDto>(aggregation)
     }
 
     /**
@@ -78,7 +80,7 @@ class NearSearchRepository(
             search {
                 index = "releaseddate"
                 near {
-                    path("released")
+                    path(Movies::released)
                     origin(LocalDateTime.of(1915, 9, 13, 0, 0, 0))
                     pivot(7776000000)
                 }
@@ -88,13 +90,13 @@ class NearSearchRepository(
 
             project {
                 excludeId()
-                +"title"
-                +"released"
+                +Movies::title
+                +Movies::released
                 searchScore()
             }
         }
 
-        return mflixMongoTemplate.aggregate(aggregation, "movies", ReleasedDto::class.java)
+        return mflixMongoTemplate.aggregate<Movies, ReleasedDto>(aggregation)
     }
 
     /**
@@ -120,7 +122,7 @@ class NearSearchRepository(
             }
         }
 
-        return airbnbMongoTemplate.aggregate(aggregation, "listingsAndReviews", GeoDto::class.java)
+        return airbnbMongoTemplate.aggregate<ListingsAndReviews, GeoDto>(aggregation)
     }
 
     /**
@@ -156,6 +158,6 @@ class NearSearchRepository(
             }
         }
 
-        return airbnbMongoTemplate.aggregate(aggregation, "listingsAndReviews", GeoPropertyTypeDto::class.java)
+        return airbnbMongoTemplate.aggregate<ListingsAndReviews, GeoPropertyTypeDto>(aggregation)
     }
 }

--- a/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/atlas/NearSearchRepository.kt
+++ b/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/atlas/NearSearchRepository.kt
@@ -15,7 +15,7 @@ import java.time.LocalDateTime
 @Repository
 class NearSearchRepository(
     @Database("sample_mflix") private val mflixMongoTemplate: MongoTemplate,
-    @Database("sample_airbnb") private val airbnbMongoTamplate: MongoTemplate,
+    @Database("sample_airbnb") private val airbnbMongoTemplate: MongoTemplate,
 ) {
 
     data class RuntimeDto(
@@ -111,7 +111,7 @@ class NearSearchRepository(
             }
         }
 
-        return airbnbMongoTamplate.aggregate(aggregation, "listingsAndReviews", GeoDto::class.java)
+        return airbnbMongoTemplate.aggregate(aggregation, "listingsAndReviews", GeoDto::class.java)
     }
 
     fun findByGeoWithCompound(): AggregationResults<GeoPropertyTypeDto> {
@@ -144,6 +144,6 @@ class NearSearchRepository(
             }
         }
 
-        return airbnbMongoTamplate.aggregate(aggregation, "listingsAndReviews", GeoPropertyTypeDto::class.java)
+        return airbnbMongoTemplate.aggregate(aggregation, "listingsAndReviews", GeoPropertyTypeDto::class.java)
     }
 }

--- a/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/atlas/NearSearchRepository.kt
+++ b/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/atlas/NearSearchRepository.kt
@@ -43,6 +43,9 @@ class NearSearchRepository(
         val score: Double,
     )
 
+    /**
+     * @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/near/#number-example">Number Example</a>
+     */
     fun findByRuntime(): AggregationResults<RuntimeDto> {
         val aggregation = aggregation {
             search {
@@ -67,6 +70,9 @@ class NearSearchRepository(
         return mflixMongoTemplate.aggregate(aggregation, "movies", RuntimeDto::class.java)
     }
 
+    /**
+     * @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/near/#date-example">Date Example</a>
+     */
     fun findByDate(): AggregationResults<ReleasedDto> {
         val aggregation = aggregation {
             search {
@@ -91,6 +97,9 @@ class NearSearchRepository(
         return mflixMongoTemplate.aggregate(aggregation, "movies", ReleasedDto::class.java)
     }
 
+    /**
+     * @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/near/#basic-example">GeoJSON Point Basic Example</a>
+     */
     fun findByGeo(): AggregationResults<GeoDto> {
         val aggregation = aggregation {
             search {
@@ -114,6 +123,9 @@ class NearSearchRepository(
         return airbnbMongoTemplate.aggregate(aggregation, "listingsAndReviews", GeoDto::class.java)
     }
 
+    /**
+     * @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/near/#compound-example">GeoJSON Point Compound Example</a>
+     */
     fun findByGeoWithCompound(): AggregationResults<GeoPropertyTypeDto> {
         val aggregation = aggregation {
             search {

--- a/example/spring-data-mongodb/src/test/kotlin/com/github/inflab/example/spring/data/mongodb/repository/atlas/NearSearchRepositoryTest.kt
+++ b/example/spring-data-mongodb/src/test/kotlin/com/github/inflab/example/spring/data/mongodb/repository/atlas/NearSearchRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.github.inflab.example.spring.data.mongodb.repository.atlas
 import com.github.inflab.example.spring.data.mongodb.extension.AtlasTest
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint
 
 @AtlasTest(database = "sample_mflix")
 class NearSearchRepositoryTest(
@@ -40,6 +41,36 @@ class NearSearchRepositoryTest(
             "Regeneration",
             "The Cheat",
             "Hell's Hinges",
+        )
+    }
+
+    "findByGeo" {
+        // when
+        val result = nearSearchRepository.findByGeo()
+
+        // then
+        result.mappedResults.take(3).map { it.name } shouldBe listOf(
+            "Ribeira Charming Duplex",
+            "DB RIBEIRA - Grey Apartment",
+            "Ribeira 24 (4)",
+        )
+    }
+
+    "findByGeoWithCompound" {
+        // when
+        val result = nearSearchRepository.findByGeoWithCompound()
+
+        // then
+        result.mappedResults.take(3).map { it.propertyType } shouldBe listOf(
+            "Apartment",
+            "Apartment",
+            "Apartment",
+        )
+
+        result.mappedResults.take(3).map { it.address.location } shouldBe listOf(
+            GeoJsonPoint(114.15027, 22.28158),
+            GeoJsonPoint(114.15082, 22.28161),
+            GeoJsonPoint(114.15007, 22.28215),
         )
     }
 })

--- a/example/spring-data-mongodb/src/test/kotlin/com/github/inflab/example/spring/data/mongodb/repository/atlas/NearSearchRepositoryTest.kt
+++ b/example/spring-data-mongodb/src/test/kotlin/com/github/inflab/example/spring/data/mongodb/repository/atlas/NearSearchRepositoryTest.kt
@@ -1,0 +1,45 @@
+package com.github.inflab.example.spring.data.mongodb.repository.atlas
+
+import com.github.inflab.example.spring.data.mongodb.extension.AtlasTest
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+
+@AtlasTest(database = "sample_mflix")
+class NearSearchRepositoryTest(
+    private val nearSearchRepository: NearSearchRepository,
+) : FreeSpec({
+
+    "findByRuntime" {
+        // when
+        val result = nearSearchRepository.findByRuntime()
+
+        // then
+        result.mappedResults.take(5).map { it.title } shouldBe listOf(
+            "The Kingdom",
+            "The Jinx: The Life and Deaths of Robert Durst",
+            "Shoah",
+            "Les Misèrables",
+            "Tokyo Trial",
+        )
+
+        result.mappedResults.take(5).map { it.runtime } shouldBe listOf(
+            279,
+            279,
+            280,
+            281,
+            277,
+        )
+    }
+
+    "findByDate" {
+        // when
+        val result = nearSearchRepository.findByDate()
+
+        // then
+        result.mappedResults.take(3).map { it.title } shouldBe listOf(
+            "Regeneration",
+            "The Cheat",
+            "Hell's Hinges",
+        )
+    }
+})


### PR DESCRIPTION
resolve #13 

---
## Show

### Database annotations
The Near Operator example uses two databases in mongodb documetation. Therefore, it is necessary to inject two MongoTemplates, so I implemented it by adding the annotation Database. Please give your opinion on this.

### pivot verification
Additionally, the document specifies that Near's pivot must be greater than 0. I'm wondering whether to add this as validation. What do you think?

### Path type settings
Origin can include Number, ISODate, and GeoJsonPoint. So path has to be name of Number, ISODate, GeoJsonPoint fields. I attempted to override methods for each type, but encountered problem due to generics not being recognized differently. So an annotation called JvmName was added.