### PR TITLE
Implement $addFields stage dsl

### DIFF
--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/AddFieldsStageDsl.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/AddFieldsStageDsl.kt
@@ -1,0 +1,78 @@
+package com.github.inflab.spring.data.mongodb.core.aggregation
+
+import com.github.inflab.spring.data.mongodb.core.aggregation.expression.AggregationExpressionDsl
+import com.github.inflab.spring.data.mongodb.core.annotation.AggregationMarker
+import com.github.inflab.spring.data.mongodb.core.extension.toDotPath
+import org.springframework.data.mongodb.core.aggregation.AddFieldsOperation
+import org.springframework.data.mongodb.core.aggregation.AggregationExpression
+import kotlin.reflect.KProperty
+
+/**
+ * A Kotlin DSL to configure $addFields stage using idiomatic Kotlin code.
+ *
+ * @author username1103
+ * @since 1.0
+ * @see <a href="https://www.mongodb.com/docs/v7.0/reference/operator/aggregation/addFields">$addFields (aggregation)</a>
+ */
+@AggregationMarker
+class AddFieldsStageDsl {
+    private val builder = AddFieldsOperation.builder()
+
+    /**
+     * Adds new fields to documents with aggregation expression.
+     */
+    infix fun String.set(configuration: AggregationExpressionDsl.() -> AggregationExpression) {
+        builder.addField(this).withValue(AggregationExpressionDsl().configuration())
+    }
+
+    /**
+     * Adds new fields to documents from a field.
+     */
+    infix fun String.set(path: KProperty<Any?>) {
+        builder.addField(this).withValue("${'$'}${path.toDotPath()}")
+    }
+
+    /**
+     * Adds new fields to documents with a value.
+     */
+    infix fun String.set(value: Any?) {
+        builder.addField(this).withValue(value)
+    }
+
+    /**
+     * Adds new fields to documents from a field.
+     */
+    infix fun String.setByField(fieldPath: String) {
+        builder.addField(this).withValue("$$fieldPath")
+    }
+
+    /**
+     * Adds new fields to documents with aggregation expression.
+     */
+    infix fun KProperty<Any?>.set(configuration: AggregationExpressionDsl.() -> AggregationExpression) {
+        builder.addField(this.toDotPath()).withValue(AggregationExpressionDsl().configuration())
+    }
+
+    /**
+     * Adds new fields to documents from a field.
+     */
+    infix fun KProperty<Any?>.set(path: KProperty<Any?>) {
+        builder.addField(this.toDotPath()).withValue("${'$'}${path.toDotPath()}")
+    }
+
+    /**
+     * Adds new fields to documents with a value.
+     */
+    infix fun KProperty<Any?>.set(value: Any?) {
+        builder.addField(this.toDotPath()).withValue(value)
+    }
+
+    /**
+     * Adds new fields to documents from a field.
+     */
+    infix fun KProperty<Any?>.setByField(fieldPath: String) {
+        builder.addField(this.toDotPath()).withValue("$$fieldPath")
+    }
+
+    internal fun get() = builder.build()
+}

--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/AddFieldsStageDsl.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/AddFieldsStageDsl.kt
@@ -20,6 +20,8 @@ class AddFieldsStageDsl {
 
     /**
      * Adds new fields to documents with aggregation expression.
+     *
+     * @param configuration The configuration block where you can use DSL to define aggregation expression.
      */
     infix fun String.set(configuration: AggregationExpressionDsl.() -> AggregationExpression) {
         builder.addField(this).withValue(AggregationExpressionDsl().configuration())
@@ -27,6 +29,8 @@ class AddFieldsStageDsl {
 
     /**
      * Adds new fields to documents from a field.
+     *
+     * @param path The path of the field to contain value to be added.
      */
     infix fun String.set(path: KProperty<Any?>) {
         builder.addField(this).withValue("${'$'}${path.toDotPath()}")
@@ -34,6 +38,8 @@ class AddFieldsStageDsl {
 
     /**
      * Adds new fields to documents with a value.
+     *
+     * @param value The value of the field to add.
      */
     infix fun String.set(value: Any?) {
         builder.addField(this).withValue(value)
@@ -41,6 +47,8 @@ class AddFieldsStageDsl {
 
     /**
      * Adds new fields to documents from a field.
+     *
+     * @param fieldPath The path of the field to contain value to be added.
      */
     infix fun String.setByField(fieldPath: String) {
         builder.addField(this).withValue("$$fieldPath")
@@ -48,6 +56,8 @@ class AddFieldsStageDsl {
 
     /**
      * Adds new fields to documents with aggregation expression.
+     *
+     * @param configuration The configuration block where you can use DSL to define aggregation expression.
      */
     infix fun KProperty<Any?>.set(configuration: AggregationExpressionDsl.() -> AggregationExpression) {
         builder.addField(this.toDotPath()).withValue(AggregationExpressionDsl().configuration())
@@ -55,6 +65,8 @@ class AddFieldsStageDsl {
 
     /**
      * Adds new fields to documents from a field.
+     *
+     * @param path The path of the field to contain value to be added.
      */
     infix fun KProperty<Any?>.set(path: KProperty<Any?>) {
         builder.addField(this.toDotPath()).withValue("${'$'}${path.toDotPath()}")
@@ -62,6 +74,8 @@ class AddFieldsStageDsl {
 
     /**
      * Adds new fields to documents with a value.
+     *
+     * @param value The value of the field to add.
      */
     infix fun KProperty<Any?>.set(value: Any?) {
         builder.addField(this.toDotPath()).withValue(value)
@@ -69,6 +83,8 @@ class AddFieldsStageDsl {
 
     /**
      * Adds new fields to documents from a field.
+     *
+     * @param fieldPath The path of the field to contain value to be added.
      */
     infix fun KProperty<Any?>.setByField(fieldPath: String) {
         builder.addField(this.toDotPath()).withValue("$$fieldPath")

--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/AggregationDsl.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/AggregationDsl.kt
@@ -289,6 +289,16 @@ class AggregationDsl {
     }
 
     /**
+     * Configures a stage that add fields in documents.
+     *
+     * @param configuration The configuration block for the [AddFieldsStageDsl].
+     * @see <a href="https://docs.mongodb.com/manual/reference/operator/aggregation/addFields">$addFields (aggregation)</a>
+     */
+    fun addFields(configuration: AddFieldsStageDsl.() -> Unit) {
+        operations += AddFieldsStageDsl().apply(configuration).get()
+    }
+
+    /**
      * Builds the [Aggregation] using the configured [AggregationOperation]s.
      *
      * @return The [Aggregation] built using the configured operations.

--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/mapping/KPropertyPath.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/mapping/KPropertyPath.kt
@@ -31,7 +31,7 @@ internal fun asString(property: KProperty<*>): String =
     }
 
 /**
- * Get field name from [Field] annotation or property name.
+ * Get field name from [Field] annotation, [Id] annotation or property name.
  *
  * @param property property to get field name from
  * @author Jake Son
@@ -47,7 +47,17 @@ internal fun toFieldName(property: KProperty<*>): String {
     val fieldAnnotation = property.javaField?.getAnnotation(Field::class.java)
 
     if (fieldAnnotation != null) {
-        return fieldAnnotation.value.ifEmpty { fieldAnnotation.name.ifEmpty { property.name } }
+        if (fieldAnnotation.value.isNotEmpty()) {
+            return fieldAnnotation.value
+        }
+
+        if (fieldAnnotation.name.isNotEmpty()) {
+            return fieldAnnotation.name
+        }
+    }
+
+    if (property.name == "id") {
+        return "_id"
     }
 
     return property.name

--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/mapping/KPropertyPath.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/mapping/KPropertyPath.kt
@@ -37,15 +37,20 @@ internal fun asString(property: KProperty<*>): String =
  * @author Jake Son
  * @since 1.0
  */
+@Suppress("detekt:style:ReturnCount")
 internal fun toFieldName(property: KProperty<*>): String {
     val idAnnotation = property.javaField?.getAnnotation(Id::class.java)
     if (idAnnotation != null) {
         return "_id"
     }
 
-    val fieldAnnotation = property.javaField?.getAnnotation(Field::class.java) ?: return property.name
+    val fieldAnnotation = property.javaField?.getAnnotation(Field::class.java)
 
-    return fieldAnnotation.value.ifEmpty { fieldAnnotation.name.ifEmpty { property.name } }
+    if (fieldAnnotation != null) {
+        return fieldAnnotation.value.ifEmpty { fieldAnnotation.name.ifEmpty { property.name } }
+    }
+
+    return property.name
 }
 
 /**

--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/mapping/KPropertyPath.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/mapping/KPropertyPath.kt
@@ -1,5 +1,6 @@
 package com.github.inflab.spring.data.mongodb.core.mapping
 
+import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Field
 import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty1
@@ -37,6 +38,11 @@ internal fun asString(property: KProperty<*>): String =
  * @since 1.0
  */
 internal fun toFieldName(property: KProperty<*>): String {
+    val idAnnotation = property.javaField?.getAnnotation(Id::class.java)
+    if (idAnnotation != null) {
+        return "_id"
+    }
+
     val fieldAnnotation = property.javaField?.getAnnotation(Field::class.java) ?: return property.name
 
     return fieldAnnotation.value.ifEmpty { fieldAnnotation.name.ifEmpty { property.name } }

--- a/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/AddFieldsStageDslTest.kt
+++ b/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/AddFieldsStageDslTest.kt
@@ -1,0 +1,204 @@
+package com.github.inflab.spring.data.mongodb.core.aggregation
+
+import com.github.inflab.spring.data.mongodb.core.util.shouldBeJson
+import io.kotest.core.spec.style.FreeSpec
+
+internal class AddFieldsStageDslTest : FreeSpec({
+
+    fun addFields(configuration: AddFieldsStageDsl.() -> Unit): AddFieldsStageDsl =
+        AddFieldsStageDsl().apply(configuration)
+
+    "set" - {
+        "should set field with path" {
+            // given
+            data class Test(val targetPath: Int)
+            val stage = addFields {
+                "a" set Test::targetPath
+            }
+
+            // when
+            val result = stage.get()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "${'$'}addFields": {
+                    "a": "${'$'}targetPath"
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        "should set field path with path" {
+            // given
+            data class Test(val sourcePath: Int, val targetPath: Int)
+            val stage = addFields {
+                Test::targetPath set Test::sourcePath
+            }
+
+            // when
+            val result = stage.get()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "${'$'}addFields": {
+                    "targetPath": "${'$'}sourcePath"
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        "should set field with aggregation expression" {
+            // given
+            data class Test(val targetPath: Int)
+            val stage = addFields {
+                "a" set {
+                    add { of(1) and 2 and Test::targetPath }
+                }
+            }
+
+            // when
+            val result = stage.get()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "${'$'}addFields": {
+                    "a": {
+                      "${'$'}add": [
+                        1,
+                        2,
+                        "${'$'}targetPath"
+                      ]
+                    }
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        "should set field path with aggregation expression" {
+            // given
+            data class Test(val sourcePath: Int, val targetPath: Int)
+            val stage = addFields {
+                Test::targetPath set {
+                    add { of(1) and 2 and Test::sourcePath }
+                }
+            }
+
+            // when
+            val result = stage.get()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "${'$'}addFields": {
+                    "targetPath": {
+                      "${'$'}add": [
+                        1,
+                        2,
+                        "${'$'}sourcePath"
+                      ]
+                    }
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        "should set field with value" {
+            // given
+            val stage = addFields {
+                "a" set 1
+            }
+
+            // when
+            val result = stage.get()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "${'$'}addFields": {
+                    "a": 1
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        "should set field path with value" {
+            // given
+            data class Test(val targetPath: Int)
+            val stage = addFields {
+                Test::targetPath set 1
+            }
+
+            // when
+            val result = stage.get()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "${'$'}addFields": {
+                    "targetPath": 1
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+    }
+
+    "setByField" - {
+        "should set field with value of other field" {
+            // given
+            val stage = addFields {
+                "a" setByField "b"
+            }
+
+            // when
+            val result = stage.get()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "${'$'}addFields": {
+                    "a": "${'$'}b"
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        "should set field path with value of other field" {
+            // given
+            data class Test(val targetPath: Int)
+            val stage = addFields {
+                Test::targetPath setByField "b"
+            }
+
+            // when
+            val result = stage.get()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "${'$'}addFields": {
+                    "targetPath": "${'$'}b"
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+    }
+})

--- a/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/mapping/KPropertyPathTest.kt
+++ b/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/mapping/KPropertyPathTest.kt
@@ -3,17 +3,20 @@ package com.github.inflab.spring.data.mongodb.core.mapping
 import com.github.inflab.spring.data.mongodb.core.extension.toDotPath
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
+import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Field
 
 internal class KPropertyPathTest : FreeSpec({
     data class Child(
+        @Id val id: Long,
         val name: String,
         val names: List<String>,
         @Field(name = "real_name") val realName: String,
         @Field("real_names") val realNames: List<String>,
         @Field(order = 1) val order: Int,
     )
-    data class Parent(val child: Child, val children: List<Child>)
+
+    data class Parent(@Field("x") @Id val id: Long, val child: Child, val children: List<Child>)
     data class GrandParent(val parent: Parent)
 
     "should return field name for a simple property" {
@@ -124,5 +127,38 @@ internal class KPropertyPathTest : FreeSpec({
 
         // then
         actual shouldBe "parent.children.name"
+    }
+
+    "should return _id for a property with @Id annotation" {
+        // given
+        val property = Child::id
+
+        // when
+        val actual = property.toDotPath()
+
+        // then
+        actual shouldBe "_id"
+    }
+
+    "should return _id for a nested property with @Id annotation" {
+        // given
+        val property = Parent::child..Child::id
+
+        // when
+        val actual = property.toDotPath()
+
+        // then
+        actual shouldBe "child._id"
+    }
+
+    "should return _id for a property with @Id and @Field annotation" {
+        // given
+        val property = Parent::id
+
+        // when
+        val actual = property.toDotPath()
+
+        // then
+        actual shouldBe "_id"
     }
 })

--- a/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/mapping/KPropertyPathTest.kt
+++ b/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/mapping/KPropertyPathTest.kt
@@ -151,7 +151,7 @@ internal class KPropertyPathTest : FreeSpec({
         actual shouldBe "child._id"
     }
 
-    "should return _id for a property with @Id and @Field annotation" {
+    "should return _id for a named id property with @Id and @Field annotation" {
         // given
         val property = Parent::id
 
@@ -160,5 +160,41 @@ internal class KPropertyPathTest : FreeSpec({
 
         // then
         actual shouldBe "_id"
+    }
+
+    "should return _id for a named id property without annotation" {
+        // given
+        data class Test(val id: Long)
+        val property = Test::id
+
+        // when
+        val actual = property.toDotPath()
+
+        // then
+        actual shouldBe "_id"
+    }
+
+    "should return _id for a named id property with empty @Field annotation" {
+        // given
+        data class Test(@Field val id: Long)
+        val property = Test::id
+
+        // when
+        val actual = property.toDotPath()
+
+        // then
+        actual shouldBe "_id"
+    }
+
+    "should return field name for a named id property with @Field annotation" {
+        // given
+        data class Test(@Field("x") val id: Long)
+        val property = Test::id
+
+        // when
+        val actual = property.toDotPath()
+
+        // then
+        actual shouldBe "x"
     }
 })

--- a/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/AddFieldsRepository.kt
+++ b/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/AddFieldsRepository.kt
@@ -1,6 +1,7 @@
 package com.github.inflab.example.spring.data.mongodb.repository
 
 import com.github.inflab.spring.data.mongodb.core.aggregation.aggregation
+import com.github.inflab.spring.data.mongodb.core.mapping.rangeTo
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.aggregate
 import org.springframework.data.mongodb.core.aggregation.AggregationResults
@@ -27,7 +28,7 @@ class AddFieldsRepository(
     fun addFieldsToEmbeddedDocument(): AggregationResults<Vehicle> {
         val aggregation = aggregation {
             addFields {
-                "specs.fuel_type" set "unleaded"
+                Vehicle::specs..Specs::fuelType set "unleaded"
             }
         }
 

--- a/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/AddFieldsRepository.kt
+++ b/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/AddFieldsRepository.kt
@@ -2,6 +2,7 @@ package com.github.inflab.example.spring.data.mongodb.repository
 
 import com.github.inflab.spring.data.mongodb.core.aggregation.aggregation
 import com.github.inflab.spring.data.mongodb.core.mapping.rangeTo
+import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.aggregate
 import org.springframework.data.mongodb.core.aggregation.AggregationResults
@@ -18,7 +19,7 @@ class AddFieldsRepository(
 
     data class Animal(val id: Long, val dogs: Long, val cats: Long)
 
-    data class Fruit(@Field("_id") val id: String, val item: String, val type: String)
+    data class Fruit(@Id val id: String, val item: String, val type: String)
 
     // TODO: https://www.mongodb.com/docs/v7.0/reference/operator/aggregation/addFields/#using-two--addfields-stages
 

--- a/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/AddFieldsRepository.kt
+++ b/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/AddFieldsRepository.kt
@@ -1,0 +1,71 @@
+package com.github.inflab.example.spring.data.mongodb.repository
+
+import com.github.inflab.spring.data.mongodb.core.aggregation.aggregation
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.aggregate
+import org.springframework.data.mongodb.core.aggregation.AggregationResults
+import org.springframework.data.mongodb.core.mapping.Field
+import org.springframework.stereotype.Repository
+
+@Repository
+class AddFieldsRepository(
+    private val mongoTemplate: MongoTemplate,
+) {
+
+    data class Specs(val doors: Long?, val wheels: Long?, @Field("fuel_type") val fuelType: String?)
+    data class Vehicle(val id: Long, val type: String, val specs: Specs?)
+
+    data class Animal(val id: Long, val dogs: Long, val cats: Long)
+
+    data class Fruit(@Field("_id") val id: String, val item: String, val type: String)
+
+    // TODO: https://www.mongodb.com/docs/v7.0/reference/operator/aggregation/addFields/#using-two--addfields-stages
+
+    /**
+     * @see <a href="https://www.mongodb.com/docs/v7.0/reference/operator/aggregation/addFields/#adding-fields-to-an-embedded-document">Adding Fields to an Embedded Document</a>
+     */
+    fun addFieldsToEmbeddedDocument(): AggregationResults<Vehicle> {
+        val aggregation = aggregation {
+            addFields {
+                "specs.fuel_type" set "unleaded"
+            }
+        }
+
+        return mongoTemplate.aggregate<Vehicle>(aggregation, VEHICLES)
+    }
+
+    /**
+     * @see <a href="https://www.mongodb.com/docs/v7.0/reference/operator/aggregation/addFields/#overwriting-an-existing-field">Overwriting an existing field</a>
+     */
+    fun overwriteAnExistingFieldWithValue(): AggregationResults<Animal> {
+        val aggregation = aggregation {
+            addFields {
+                Animal::cats set 20
+            }
+        }
+
+        return mongoTemplate.aggregate<Animal>(aggregation, ANIMALS)
+    }
+
+    /**
+     * @see <a href="https://www.mongodb.com/docs/v7.0/reference/operator/aggregation/addFields/#overwriting-an-existing-field">Overwriting an existing field</a>
+     */
+    fun overwriteAnExistingFieldWithField(): AggregationResults<Fruit> {
+        val aggregation = aggregation {
+            addFields {
+                Fruit::id set Fruit::item
+                Fruit::item set "fruit"
+            }
+        }
+
+        return mongoTemplate.aggregate<Fruit>(aggregation, FRUITS)
+    }
+
+    // TODO: https://www.mongodb.com/docs/v7.0/reference/operator/aggregation/addFields/#add-element-to-an-array
+
+    companion object {
+        const val VEHICLES = "vehicles"
+        const val ANIMALS = "animals"
+        const val FRUITS = "fruits"
+    }
+}

--- a/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/SortRepository.kt
+++ b/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/SortRepository.kt
@@ -2,7 +2,9 @@ package com.github.inflab.example.spring.data.mongodb.repository
 
 import com.github.inflab.spring.data.mongodb.core.aggregation.aggregation
 import org.bson.Document
+import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.aggregate
 import org.springframework.data.mongodb.core.aggregation.AggregationResults
 import org.springframework.data.mongodb.core.query.TextCriteria
 import org.springframework.stereotype.Repository
@@ -12,18 +14,24 @@ class SortRepository(
     private val mongoTemplate: MongoTemplate,
 ) {
 
+    data class Restaurant(
+        @Id val id: Long,
+        val name: String,
+        val borough: String,
+    )
+
     /**
      * @see <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/#sort-consistency">Sort Consistency</a>
      */
-    fun sortByBorough(): AggregationResults<Document> {
+    fun sortByBorough(): AggregationResults<Restaurant> {
         val aggregation = aggregation {
             sort {
-                "borough" by asc
-                "_id" by asc
+                Restaurant::borough by asc
+                Restaurant::id by asc
             }
         }
 
-        return mongoTemplate.aggregate(aggregation, RESTAURANTS, Document::class.java)
+        return mongoTemplate.aggregate<Restaurant>(aggregation, RESTAURANTS)
     }
 
     /**

--- a/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/UnionWithRepository.kt
+++ b/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/UnionWithRepository.kt
@@ -1,6 +1,7 @@
 package com.github.inflab.example.spring.data.mongodb.repository
 
 import com.github.inflab.spring.data.mongodb.core.aggregation.aggregation
+import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.aggregation.Aggregation
 import org.springframework.data.mongodb.core.aggregation.AggregationResults
@@ -13,7 +14,7 @@ class UnionWithRepository(
 ) {
 
     data class SalesDto(
-        val id: String,
+        @Id val id: String,
         val store: String,
         val item: String,
         val quantity: Int,
@@ -47,7 +48,7 @@ class UnionWithRepository(
             }
 
             sort {
-                "_id" by asc
+                SalesDto::id by asc
                 "store" by asc
                 "item" by asc
             }

--- a/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/atlas/MoreLikeThisSearchRepository.kt
+++ b/example/spring-data-mongodb/src/main/kotlin/com/github/inflab/example/spring/data/mongodb/repository/atlas/MoreLikeThisSearchRepository.kt
@@ -70,7 +70,7 @@ class MoreLikeThisSearchRepository(
 
                     mustNot {
                         equal {
-                            path("_id")
+                            path(Movies::id)
                             value(ObjectId("573a1396f29313caabce4a9a"))
                         }
                     }
@@ -134,7 +134,7 @@ class MoreLikeThisSearchRepository(
 
                     mustNot {
                         equal {
-                            path("_id")
+                            path(Movies::id)
                             value(ObjectId("573a1394f29313caabcde9ef"))
                         }
                     }

--- a/example/spring-data-mongodb/src/test/kotlin/com/github/inflab/example/spring/data/mongodb/repository/AddFieldsRepositoryTest.kt
+++ b/example/spring-data-mongodb/src/test/kotlin/com/github/inflab/example/spring/data/mongodb/repository/AddFieldsRepositoryTest.kt
@@ -1,0 +1,100 @@
+package com.github.inflab.example.spring.data.mongodb.repository
+
+import com.github.inflab.example.spring.data.mongodb.extension.makeMongoTemplate
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import org.bson.Document
+
+internal class AddFieldsRepositoryTest : FreeSpec({
+    val mongoTemplate = makeMongoTemplate()
+    val addFieldsRepository = AddFieldsRepository(mongoTemplate)
+
+    "addFieldsToEmbeddedDocument" {
+        // given
+        val documents = listOf(
+            mapOf("_id" to 1, "type" to "car", "specs" to mapOf("doors" to 4, "wheels" to 4)),
+            mapOf("_id" to 2, "type" to "motorcycle", "specs" to mapOf("doors" to 0, "wheels" to 2)),
+            mapOf("_id" to 3, "type" to "jet ski"),
+        ).map(::Document)
+
+        mongoTemplate.insert(documents, AddFieldsRepository.VEHICLES)
+
+        // when
+        val result = addFieldsRepository.addFieldsToEmbeddedDocument().mappedResults
+
+        // then
+        result[0] shouldBe AddFieldsRepository.Vehicle(
+            id = 1,
+            type = "car",
+            specs = AddFieldsRepository.Specs(
+                doors = 4,
+                wheels = 4,
+                fuelType = "unleaded",
+            ),
+        )
+        result[1] shouldBe AddFieldsRepository.Vehicle(
+            id = 2,
+            type = "motorcycle",
+            specs = AddFieldsRepository.Specs(
+                doors = 0,
+                wheels = 2,
+                fuelType = "unleaded",
+            ),
+        )
+        result[2] shouldBe AddFieldsRepository.Vehicle(
+            id = 3,
+            type = "jet ski",
+            specs = AddFieldsRepository.Specs(
+                doors = null,
+                wheels = null,
+                fuelType = "unleaded",
+            ),
+        )
+    }
+
+    "overwriteAnExistingFieldWithValue" {
+        // given
+        val document = mapOf("_id" to 1, "dogs" to 10, "cats" to 15).let(::Document)
+        mongoTemplate.insert(document, AddFieldsRepository.ANIMALS)
+
+        // when
+        val result = addFieldsRepository.overwriteAnExistingFieldWithValue().mappedResults
+
+        // then
+        result[0] shouldBe AddFieldsRepository.Animal(
+            id = 1,
+            dogs = 10,
+            cats = 20,
+        )
+    }
+
+    "overwriteAnExistingFieldWithField" {
+        // given
+        val documents = listOf(
+            mapOf("_id" to 1, "item" to "tangerine", "type" to "citrus"),
+            mapOf("_id" to 2, "item" to "lemon", "type" to "citrus"),
+            mapOf("_id" to 3, "item" to "grapefruit", "type" to "citrus"),
+        ).map(::Document)
+        mongoTemplate.insert(documents, AddFieldsRepository.FRUITS)
+
+        // when
+        val result = addFieldsRepository.overwriteAnExistingFieldWithField().mappedResults
+
+        // then
+        result[0] shouldBe AddFieldsRepository.Fruit(
+            id = "tangerine",
+            item = "fruit",
+            type = "citrus",
+        )
+        result[1] shouldBe AddFieldsRepository.Fruit(
+            id = "lemon",
+            item = "fruit",
+            type = "citrus",
+        )
+        result[2] shouldBe AddFieldsRepository.Fruit(
+            id = "grapefruit",
+            item = "fruit",
+            type = "citrus",
+        )
+    }
+})

--- a/example/spring-data-mongodb/src/test/kotlin/com/github/inflab/example/spring/data/mongodb/repository/SortRepositoryTest.kt
+++ b/example/spring-data-mongodb/src/test/kotlin/com/github/inflab/example/spring/data/mongodb/repository/SortRepositoryTest.kt
@@ -38,7 +38,7 @@ internal class SortRepositoryTest : FreeSpec({
         val result = sortRepository.sortByBorough()
 
         // then
-        result.mappedResults.map { it["_id"] } shouldBe listOf(3, 5, 1, 4, 2)
+        result.mappedResults.map { it.id } shouldBe listOf(3, 5, 1, 4, 2)
     }
 
     "sortByScore" {


### PR DESCRIPTION
resolve #79 

---

Currently, the $sum operator is implemented as follows.

https://github.com/inflearn/spring-data-mongodb-kotlin-dsl/blob/661cc3e9c24b525b82e7da81be429fbe3b2ec96b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/expression/AggregationExpressionDsl.kt#L176-L178

But We need to use it as follows.

```
db.scores.aggregate( [
   {
     $addFields: {
       totalHomework: { $sum: "$homework" } ,
       totalQuiz: { $sum: "$quiz" }
     }
   },
   {
     $addFields: { totalScore:
       { $add: [ "$totalHomework", "$totalQuiz", "$extraCredit" ] } }
   }
] )
```