### PR TITLE
feat: add search pagination operation

### DIFF
--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/ProjectStageDsl.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/ProjectStageDsl.kt
@@ -139,6 +139,16 @@ class ProjectStageDsl {
         addMetaDataKeyword("indexKey", alias)
     }
 
+    /**
+     * Specifies an alias that contains the search sequence token for paginating through Atlas Search results.
+     *
+     * @param alias The alias for the field.
+     * @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/paginate-results/#paginate-the-results">Paginate the results</a>
+     */
+    fun searchSequenceToken(alias: String = "paginationToken") {
+        addMetaDataKeyword("searchSequenceToken", alias)
+    }
+
     private fun addMetaDataKeyword(keyword: String, alias: String) {
         operation = operation.andExpression("{\$meta: \"$keyword\"}").`as`(alias)
     }

--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/SearchStageDsl.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/SearchStageDsl.kt
@@ -60,6 +60,28 @@ class SearchStageDsl : SearchOperator by SearchOperatorDsl(), SearchCollector by
         }
 
     /**
+     * A token that specifies the point after which to return search results.
+     *
+     * @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/paginate-results/#search-after-a-specific-point-of-reference">Search After</a>
+     */
+    var searchAfter: String? = null
+        set(value) {
+            value?.let { document["searchAfter"] = it }
+            field = value
+        }
+
+    /**
+     * A token that specifies the point before which to return search results.
+     *
+     * @see <a href="https://www.mongodb.com/docs/atlas/atlas-search/paginate-results/#search-before-a-specific-point-of-reference">Search Before</a>
+     */
+    var searchBefore: String? = null
+        set(value) {
+            value?.let { document["searchBefore"] = it }
+            field = value
+        }
+
+    /**
      * Configures an option to include a lower bound count of the number of documents that match the query.
      *
      * @param threshold Number of documents to include in the exact count.

--- a/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/ProjectStageDslTest.kt
+++ b/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/ProjectStageDslTest.kt
@@ -245,6 +245,31 @@ internal class ProjectStageDslTest : FreeSpec({
         }
     }
 
+    "searchSequenceToken" - {
+        "should add search sequence token meta with given alias" {
+            // given
+            val stage = project {
+                searchSequenceToken("alias")
+            }
+
+            // when
+            val result = stage.get()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "${'$'}project": {
+                    "alias": {
+                      "${'$'}meta": "searchSequenceToken"
+                    }
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+    }
+
     "searchHighlights" - {
         "should add search highlights meta with given alias" {
             // given

--- a/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/SearchStageDslTest.kt
+++ b/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/SearchStageDslTest.kt
@@ -257,4 +257,50 @@ internal class SearchStageDslTest : FreeSpec({
             )
         }
     }
+
+    "searchAfter" - {
+        "should build a searchAfter option" {
+            // given
+            val stage = search {
+                searchAfter = "token"
+            }
+
+            // when
+            val result = stage.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "${"$"}search": {
+                    "searchAfter": "token"
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+    }
+
+    "searchBefore" - {
+        "should build a searchBefore option" {
+            // given
+            val stage = search {
+                searchBefore = "token"
+            }
+
+            // when
+            val result = stage.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "${"$"}search": {
+                    "searchBefore": "token"
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+    }
 })


### PR DESCRIPTION
resolve #110 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Atlas Search 결과에 대한 페이지 매김 지원 추가 — 시퀀스 토큰과 이전/이후 검색 옵션(searchBefore/searchAfter)으로 결과 탐색 개선.

* **테스트**
  * 시퀀스 토큰 및 이전/이후 검색 옵션 동작을 검증하는 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->