### PR TITLE
feat: add string value of equals operator

### DIFF
--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/EqualsSearchOperatorDsl.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/EqualsSearchOperatorDsl.kt
@@ -73,6 +73,15 @@ class EqualsSearchOperatorDsl {
     }
 
     /**
+     * Value to query for string, indexed as MongoDB Search token type.
+     *
+     * @param value Value must be a string.
+     */
+    fun value(value: String) {
+        document["value"] = value
+    }
+
+    /**
      * The score assigned to matching search term results. Use one of the following options to modify the score:
      *
      * - boost: multiply the result score by the given number.

--- a/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/EqualsSearchOperatorDslTest.kt
+++ b/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/EqualsSearchOperatorDslTest.kt
@@ -168,6 +168,27 @@ internal class EqualsSearchOperatorDslTest : FreeSpec({
                 """.trimIndent(),
             )
         }
+
+        "should build a value by String" {
+            // given
+            val operator = equal {
+                value("stringValue")
+            }
+
+            // when
+            val result = operator.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "equals": {
+                    "value": "stringValue"
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
     }
 
     "score" - {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Equals 검색 연산자에서 문자열 값 지원을 추가했습니다.
  * MongoDB 검색에서 문자열 타입의 쿼리를 통해 더욱 유연한 검색이 가능합니다.

* **테스트**
  * 문자열 값에 대한 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->