### PR TITLE
feat: add token type value for in search operator

### DIFF
--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/InSearchOperatorDsl.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/InSearchOperatorDsl.kt
@@ -140,5 +140,26 @@ class InSearchOperatorDsl {
         document["value"] = value
     }
 
+    /**
+     * Value or values to search.
+     * Value can be either a single value or an array of values of only one of the supported BSON types and can't be a mix of different types.
+     *
+     * @param value Values to search.
+     */
+    fun value(vararg value: String) {
+        document["value"] = value.toList()
+    }
+
+    /**
+     * Value or values to search.
+     * Value can be either a single value or an array of values of only one of the supported BSON types and can't be a mix of different types.
+     *
+     * @param value Values to search.
+     */
+    @JvmName("valueStringIterable")
+    fun value(value: Iterable<String>) {
+        document["value"] = value
+    }
+
     internal fun build() = Document("in", document)
 }

--- a/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/InSearchOperatorDslTest.kt
+++ b/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/InSearchOperatorDslTest.kt
@@ -298,6 +298,54 @@ internal class InSearchOperatorDslTest : FreeSpec({
                 """.trimIndent(),
             )
         }
+
+        "should build a value by string" {
+            // given
+            val operator = `in` {
+                value("value1")
+            }
+
+            // when
+            val result = operator.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "in": {
+                    "value": [
+                      "value1"
+                    ]
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        "should build a value by multiple strings" {
+            // given
+            val operator = `in` {
+                value("value1", "value2", "value3")
+            }
+
+            // when
+            val result = operator.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "in": {
+                    "value": [
+                      "value1",
+                      "value2",
+                      "value3"
+                    ]
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
     }
 
     "score" - {


### PR DESCRIPTION
https://www.mongodb.com/docs/atlas/atlas-search/operators-collectors/in/#in-operator

add token type value for in search operator


> 
value | boolean, objectId, number, date, uuid, or string | Value or values to search. Value can be either a single value or an array of values of only one of the supported BSON types and can't be a mix of different types. To search for string values in a field, you must index the field as the MongoDB Search token type. | Required
-- | -- | -- | --


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* In 검색 연산자에서 문자열 값 지원: 단일 또는 여러 문자열 값을 직접 전달하여 검색 조건 구성 가능

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->