### PR TITLE
feat: add match criteria option for text search operator

### DIFF
--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/TextMatchCriteria.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/TextMatchCriteria.kt
@@ -1,0 +1,21 @@
+package com.github.inflab.spring.data.mongodb.core.aggregation.search
+
+/**
+ * Defines the criteria to use to match the terms in the query.
+ * The default value is [TextMatchCriteria.ANY].
+ *
+ * @author username1103
+ * @since 1.0
+ */
+enum class TextMatchCriteria {
+
+    /**
+     * Indicates that Atlas Search returns documents that contain any of the terms from the query field.
+     */
+    ANY,
+
+    /**
+     * Indicates that Atlas Search returns documents that contain all of the terms from the query field.
+     */
+    ALL,
+}

--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/TextSearchOperatorDsl.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/TextSearchOperatorDsl.kt
@@ -110,6 +110,17 @@ class TextSearchOperatorDsl {
     }
 
     /**
+     * The criteria to use to match the terms in the query.
+     * The default value is [TextMatchCriteria.ANY].
+     * We recommend that you always include the matchCriteria option when you use the synonyms option.
+     *
+     * @param matchCriteria The criteria to use to match the terms in the query. [TextMatchCriteria]
+     */
+    fun matchCriteria(matchCriteria: TextMatchCriteria) {
+        document["matchCriteria"] = matchCriteria.name.lowercase()
+    }
+
+    /**
      * The score assigned to matching search term results. Use one of the following options to modify the score:
      *
      * - boost: multiply the result score by the given number.

--- a/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/TextSearchOperatorDslTest.kt
+++ b/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/TextSearchOperatorDslTest.kt
@@ -283,6 +283,50 @@ internal class TextSearchOperatorDslTest : FreeSpec({
         }
     }
 
+    "matchCriteria" - {
+        "should build a matchCriteria with any" {
+            // given
+            val operator = text {
+                matchCriteria(TextMatchCriteria.ANY)
+            }
+
+            // when
+            val result = operator.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "text": {
+                    "matchCriteria": "any"
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        "should build a matchCriteria with all" {
+            // given
+            val operator = text {
+                matchCriteria(TextMatchCriteria.ALL)
+            }
+
+            // when
+            val result = operator.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "text": {
+                    "matchCriteria": "all"
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+    }
+
     "score" - {
         "should build a score" {
             // given


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 텍스트 검색 시 쿼리 용어 매칭 방식을 명시적으로 설정할 수 있는 기능이 추가되었습니다. 이제 "모든 용어 포함"(ALL) 또는 "하나 이상의 용어 포함"(ANY) 중 원하는 방식을 선택하여 검색 동작을 제어할 수 있습니다.

## 테스트

* 새로운 매칭 방식 설정 기능에 대한 검증 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->