### PR TITLE
feat: add synonyms option for phrase search operator

### DIFF
--- a/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/PhraseSearchOperatorDsl.kt
+++ b/core/src/main/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/PhraseSearchOperatorDsl.kt
@@ -110,5 +110,16 @@ class PhraseSearchOperatorDsl {
         document["score"] = ScoreSearchOptionDsl().apply(scoreConfiguration).get()
     }
 
+    /**
+     * Required for running queries using synonyms.
+     * Name of the synonym mapping definition in the index definition.
+     * Value can't be an empty string.
+     *
+     * @param value Name of the synonym mapping definition in the index definition.
+     */
+    fun synonyms(value: String) {
+        document["synonyms"] = value
+    }
+
     internal fun build() = Document("phrase", document)
 }

--- a/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/PhraseSearchOperatorDslTest.kt
+++ b/core/src/test/kotlin/com/github/inflab/spring/data/mongodb/core/aggregation/search/PhraseSearchOperatorDslTest.kt
@@ -260,4 +260,27 @@ internal class PhraseSearchOperatorDslTest : FreeSpec({
             )
         }
     }
+
+    "synonyms" - {
+        "should build a synonyms" {
+            // given
+            val operator = phrase {
+                synonyms("synonyms")
+            }
+
+            // when
+            val result = operator.build()
+
+            // then
+            result.shouldBeJson(
+                """
+                {
+                  "phrase": {
+                    "synonyms": "synonyms"
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+    }
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Phrase 검색에서 동의어(Synonyms) 매핑을 설정할 수 있는 기능이 추가되었습니다. 이를 통해 검색 시 동의어 규칙을 적용해 더 유연한 결과를 얻을 수 있습니다.

* **Tests**
  * 동의어 설정 동작을 검증하는 단위 테스트가 추가되어 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->